### PR TITLE
Remove field from entity structs

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -75,7 +75,6 @@ typedef struct
 	u32		model_id;
 	u32		beam_type;
 	u32		field_8C;
-	u32		field_90;
 } EntityJumpPad;
 
 typedef struct
@@ -97,7 +96,6 @@ typedef struct
 	int		field_38;
 	int		field_3C;
 	int		field_40;
-	int		field_44;
 } EntityItem;
 
 struct CEntity;


### PR DESCRIPTION
Looks like these structs should have the same size as the length value on their entity entry (148 for jump pad, 72 for item). Taking `mp3_Ent.bin` as an example, the last of the 27 entity entries has offset value 2840 and length 72, which is exactly enough to reach the end of the file.

Having them isn't causing any issues though, since the reads in [EntLoad](https://github.com/hackyourlife/mph-viewer/blob/e8a5a37d92764835b4ff88541042b246eb90a2c7/src/entity.c#L46) are limited to the entry length rather than the struct size, so the fields are just never getting populated.