### PR TITLE
Always set render mode, even for untextured materials

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -679,6 +679,7 @@ static void make_textures(CModel* scn, Material* materials, unsigned int num_mat
 	u32 m;
 	for(m = 0; m < num_materials; m++) {
 		Material* mat = &materials[m];
+		scn->materials[m].render_mode = mat->render_mode;
 		if(mat->texid == 0xFFFF)
 			continue;
 		if(mat->texid >= num_textures) {
@@ -833,7 +834,6 @@ static void make_textures(CModel* scn, Material* materials, unsigned int num_mat
 				break;
 			}
 		}
-		scn->materials[m].render_mode = mat->render_mode;
 		if(mat->alpha < 31) {
 			scn->materials[m].render_mode = TRANSLUCENT;
 		}


### PR DESCRIPTION
Ensure the render mode is set for materials without a texture ID. This fixes a bug where the letter E in the Energy Tank model was rendering on top of the rest of the model.

Because the render mode wasn't set, untextured materials in entities were always being picked up in "pass 2: translucent" even if the material had render mode Normal and needed to be in the first pass.

This doesn't affect room rendering. Untextured room materials will technically now get picked up in one of the four render passes, but they will be ignored because the room render passes are all called with `render_notex = 0`. So those weird `etagDoor` blobs still won't show up.