### PR TITLE
Fix node angles

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -1086,8 +1086,8 @@ CModel* CModel_load(u8* scenedata, unsigned int scenesize, u8* texturedata, unsi
 		node->scale.y = FX_FX32_TO_F32((fx32) get32bit_LE((u8*)&raw->scale.y));
 		node->scale.z = FX_FX32_TO_F32((fx32) get32bit_LE((u8*)&raw->scale.z));
 		node->angle.x = get16bit_LE((u8*)&raw->angle_x) / 65536.0 * 2.0 * M_PI;
-		node->angle.y = get16bit_LE((u8*)&raw->angle_x) / 65536.0 * 2.0 * M_PI;
-		node->angle.z = get16bit_LE((u8*)&raw->angle_x) / 65536.0 * 2.0 * M_PI;
+		node->angle.y = get16bit_LE((u8*)&raw->angle_y) / 65536.0 * 2.0 * M_PI;
+		node->angle.z = get16bit_LE((u8*)&raw->angle_z) / 65536.0 * 2.0 * M_PI;
 		node->pos.x = FX_FX32_TO_F32((fx32) get32bit_LE((u8*)&raw->pos.x));
 		node->pos.y = FX_FX32_TO_F32((fx32) get32bit_LE((u8*)&raw->pos.y));
 		node->pos.z = FX_FX32_TO_F32((fx32) get32bit_LE((u8*)&raw->pos.z));


### PR DESCRIPTION
This was causing another minor bug with the Energy Tank. There are two nodes for the letter E, one of them rotated so that it looks the same from the front and back. Without this rotation, they were both facing forward, so the E was invisible from behind.