### PR TITLE
Fix secret switch node animation

### DIFF
--- a/include/animation.h
+++ b/include/animation.h
@@ -10,6 +10,6 @@ void CAnimation_free(CAnimation* animation);
 void CAnimation_process(CAnimation* animation, float dt);
 void process_texcoord_animation(CTexcoordAnimationGroup* group, int id, int width, int height, Mtx44* texcoord);
 void process_material_animation(CMaterialAnimationGroup* group, int id, CMaterial* material);
-void process_node_animation(CNodeAnimationGroup* group, Mtx44* root_transform, float scale);
+void process_node_animation(CNodeAnimationGroup* group, float scale);
 
 #endif

--- a/src/animation.c
+++ b/src/animation.c
@@ -821,22 +821,15 @@ void get_srt(CNodeAnimationGroup* group, CNodeAnimation* anim, int frame, Vec3* 
 	}
 }
 
-void process_node_animation(CNodeAnimationGroup* group, Mtx44* root_transform, float mdlscale)
+void process_node_animation(CNodeAnimationGroup* group, float mdlscale)
 {
 	unsigned int i;
 	CNode* nodes = group->nodes;
 
 	for(i = 0; i < group->num_nodes; i++) {
 		Mtx44 srt;
-		Mtx44* transform;
 		CNode* node = &nodes[i];
 		CNodeAnimation* anim = &group->animations[i];
-
-		if(node->parent >= 0) {
-			transform = &nodes[node->parent].node_transform;
-		} else {
-			transform = root_transform;
-		}
 
 		if(anim->flags & NODE_ANIM_DISABLE) {
 			MTX44Identity(&srt);
@@ -850,7 +843,13 @@ void process_node_animation(CNodeAnimationGroup* group, Mtx44* root_transform, f
 			scale_rotate_translate(&srt, scale.x, scale.y, scale.z, rot.x, rot.y, rot.z, translate.x / mdlscale, translate.y / mdlscale, translate.z / mdlscale);
 		}
 
-		MTX44Concat(transform, &srt, &node->node_transform);
+		if (node->parent >= 0)
+		{
+			MTX44Concat(&nodes[node->parent].node_transform, &srt, &node->node_transform);
+		} else
+		{
+			MTX44Copy(&srt, &node->node_transform);
+		}
 	}
 }
 

--- a/src/animation.c
+++ b/src/animation.c
@@ -846,8 +846,7 @@ void process_node_animation(CNodeAnimationGroup* group, float mdlscale)
 		if (node->parent >= 0)
 		{
 			MTX44Concat(&nodes[node->parent].node_transform, &srt, &node->node_transform);
-		} else
-		{
+		} else {
 			MTX44Copy(&srt, &node->node_transform);
 		}
 	}

--- a/src/model.c
+++ b/src/model.c
@@ -2014,7 +2014,7 @@ void CModel_render_all(CModel* scene, Mtx44* mtx, float alpha)
 	MTX44ScaleApply(mtx, &mat, scene->scale, scene->scale, scene->scale);
 
 	if(scene->node_animation) {
-		process_node_animation(scene->node_animation, &mat, scene->scale);
+		process_node_animation(scene->node_animation, scene->scale);
 	}
 
 	glUseProgram(shader);
@@ -2030,9 +2030,7 @@ void CModel_render_all(CModel* scene, Mtx44* mtx, float alpha)
 		if(node->mesh_count) {
 			int mesh_id = node->mesh_id / 2;
 
-			if(scene->node_animation) {
-				MTX44Copy(&node->node_transform, &transform);
-			} else if(scene->apply_transform) {
+			if(scene->node_animation || scene->apply_transform) {
 				MTX44Concat(&mat, &node->node_transform, &transform);
 			} else {
 				MTX44Copy(&mat, &transform);

--- a/src/object.c
+++ b/src/object.c
@@ -156,13 +156,6 @@ void load_object(unsigned int id)
 		// 	sprintf(filename, "models/%s_Collision.bin", objects[id].collision_name);
 		// 	load_collision(&object_collision[id], filename, 0);
 		// }
-		if(id >= 0x2F && id <= 0x34) {
-			int i;
-			for(i = 47; i < 0x34; i = (i + 1) & 0xFF) {
-				object_anim[i] = object_anim[id];
-				// object_collision[i] = object_collision[id];
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
- Multiply the model transform outside of the node animation function
- Remove shared animation objects for the secret switches