### PR TITLE
Toon shading + light override

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -327,6 +327,7 @@ void		EntForceFieldRegister(void);
 void		EntArtifactRegister(void);
 
 void		get_transform_mtx(Mtx44* mtx, VecFx32* vec1, VecFx32* vec2);
+void		get_transform_mtx3(Mtx44* mtx, Vec3* vec1, Vec3* vec2);
 
 float		CItem_get_y(fx32 y);
 void		CForceField_set_state(CEntity* obj, int state);

--- a/include/model.h
+++ b/include/model.h
@@ -230,6 +230,7 @@ typedef struct {
 	Mtx44*				texture_matrices;
 
 	bool				apply_transform;
+	bool				light_override;
 
 	float				min_x;
 	float				max_x;
@@ -247,7 +248,7 @@ typedef struct {
 int	get_node_child(const char* name, CModel* scene);
 void	scale_rotate_translate(Mtx44* mtx, float sx, float sy, float sz, float ax, float ay, float az, float x, float y, float z);
 void	CModel_init(void);
-void	CModel_setLights(float l1vec[4], float l1col[4], float l2vec[4], float l2col[4]);
+void	CModel_setLights(float l1vec[3], float l1col[3], float l2vec[3], float l2col[3]);
 void	CModel_setFog(bool en, float fogc[4], int fogoffset);
 void	CModel_setFogDisable(bool dis);
 void	load_model(CModel** model, const char* filename, int flags);
@@ -263,5 +264,11 @@ void	CModel_compute_node_matrices(CModel* model, int start_idx);
 
 void	CModel_begin_scene(void);
 void	CModel_end_scene(void);
+
+#define TOON_SIZE 32
+
+#define GetTableColor(c) (((c >> 0) & 0x1F) / 31.0f), (((c >> 5) & 0x1F) / 31.0f), (((c >> 10) & 0x1F) / 31.0f)
+
+extern const float toon_values[TOON_SIZE * 3];
 
 #endif

--- a/include/vec.h
+++ b/include/vec.h
@@ -4,7 +4,9 @@
 #include "types.h"
 
 void VEC_CrossProduct(const VecFx32 *a, const VecFx32 *b, VecFx32 *axb);
+void VEC_CrossProduct3(const Vec3 *a, const Vec3 *b, Vec3 *axb);
 void VEC_Normalize(const VecFx32 *src, VecFx32 *dst);
+void VEC_Normalize3(const Vec3 *src, Vec3 *dst);
 void MTX_MultVec33(const VecFx32* vec, const MtxFx33* m, VecFx32* dst);
 
 #endif

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -44,6 +44,7 @@ static void load_artifact(unsigned int artifact_id)
 		if(!octolith_model) {
 			load_model(&octolith_model, "models/Octolith_Model.bin", 0);
 			load_animation(&octolith_anim, "models/Octolith_Anim.bin", octolith_model, 0);
+			octolith_model->light_override = true;
 		}
 	} else if(!artifact_models[artifact_id]) {
 		sprintf(filename, "models/Artifact%02d_mdl_Model.bin", artifact_id + 1);

--- a/src/entity.c
+++ b/src/entity.c
@@ -291,3 +291,33 @@ void get_transform_mtx(Mtx44* mtx, VecFx32* vec1, VecFx32* vec2)
 	mtx->m[3][2] = 0;
 	mtx->m[3][3] = 1;
 }
+
+void get_transform_mtx3(Mtx44* mtx, Vec3* vec1, Vec3* vec2)
+{
+	Vec3 up;
+	Vec3 dir;
+
+	VEC_CrossProduct3(vec2, vec1, &up);
+	VEC_Normalize3(&up, &up);
+	VEC_CrossProduct3(vec1, &up, &dir);
+
+	mtx->m[0][0] = up.x;
+	mtx->m[0][1] = up.y;
+	mtx->m[0][2] = up.z;
+	mtx->m[0][3] = 0;
+
+	mtx->m[1][0] = dir.x;
+	mtx->m[1][1] = dir.y;
+	mtx->m[1][2] = dir.z;
+	mtx->m[1][3] = 0;
+
+	mtx->m[2][0] = vec1->x;
+	mtx->m[2][1] = vec1->y;
+	mtx->m[2][2] = vec1->z;
+	mtx->m[2][3] = 0;
+
+	mtx->m[3][0] = 0;
+	mtx->m[3][1] = 0;
+	mtx->m[3][2] = 0;
+	mtx->m[3][3] = 1;
+}

--- a/src/model.c
+++ b/src/model.c
@@ -1829,8 +1829,7 @@ void CModel_render_mesh(CModel* scene, int mesh_id, MtxFx44* transform)
 			l2c_override[2] = 1;
 			glUniform3fv(light1col, 1, l1c_override);
 			glUniform3fv(light2col, 1, l2c_override);
-		}
-		else
+		} else
 		{
 			use_room_lights();
 		}

--- a/src/model.c
+++ b/src/model.c
@@ -1963,7 +1963,7 @@ void CModel_end_scene(void)
 	}
 
 	// depth sort
-	// qsort(sorted, render_count, sizeof(RenderEntity*), RenderEntity_sort);	
+	// qsort(sorted, render_count, sizeof(RenderEntity*), RenderEntity_sort);
 
 	glUseProgram(shader);
 

--- a/src/model.c
+++ b/src/model.c
@@ -1718,7 +1718,7 @@ extern bool texturing;
 extern float pos_x;
 extern float pos_y;
 extern float pos_z;
-void CModel_render_mesh(CModel* scene, int mesh_id, MtxFx44* transform)
+void CModel_render_mesh(CModel* scene, int mesh_id, Mtx44* transform)
 {
 	if(mesh_id >= scene->num_meshes) {
 		printf("trying to render mesh %d, but scene only has %d meshes\n", mesh_id, scene->num_meshes);

--- a/src/model.c
+++ b/src/model.c
@@ -1783,8 +1783,7 @@ void CModel_render_mesh(CModel* scene, int mesh_id, MtxFx44* transform)
 		glUniform3fv(diffuse, 1, diff);
 		glUniform3fv(specular, 1, spec);
 		glUniform1i(use_light, 1);
-		if (scene->light_override)
-		{
+		if (scene->light_override) {
 			Mtx44 light_transform;
 			Vec3 pos;
 			Vec3 vec1;
@@ -1829,8 +1828,7 @@ void CModel_render_mesh(CModel* scene, int mesh_id, MtxFx44* transform)
 			l2c_override[2] = 1;
 			glUniform3fv(light1col, 1, l1c_override);
 			glUniform3fv(light2col, 1, l2c_override);
-		} else
-		{
+		} else {
 			use_room_lights();
 		}
 	} else {

--- a/src/room.c
+++ b/src/room.c
@@ -103,10 +103,10 @@ void CRoom_free(CRoom* room)
 
 void CRoom_setLights(CRoom* room)
 {
-	float light_1_vec[4] = { FX_FX32_TO_F32(room->description->light_1_vec.x), FX_FX32_TO_F32(room->description->light_1_vec.y), FX_FX32_TO_F32(room->description->light_1_vec.z), 0 };
-	float light_1_col[4] = { room->description->light_1_color.r / 255.0f, room->description->light_1_color.g / 255.0f, room->description->light_1_color.b / 255.0f, room->description->light_1_color.a / 255.0f };
-	float light_2_vec[4] = { FX_FX32_TO_F32(room->description->light_2_vec.x), FX_FX32_TO_F32(room->description->light_2_vec.y), FX_FX32_TO_F32(room->description->light_2_vec.z), 0 };
-	float light_2_col[4] = { room->description->light_2_color.r / 255.0f, room->description->light_2_color.g / 255.0f, room->description->light_2_color.b / 255.0f, room->description->light_2_color.a / 255.0f };
+	float light_1_vec[3] = { FX_FX32_TO_F32(room->description->light_1_vec.x), FX_FX32_TO_F32(room->description->light_1_vec.y), FX_FX32_TO_F32(room->description->light_1_vec.z) };
+	float light_1_col[3] = { room->description->light_1_color.r / 255.0f, room->description->light_1_color.g / 255.0f, room->description->light_1_color.b / 255.0f };
+	float light_2_vec[3] = { FX_FX32_TO_F32(room->description->light_2_vec.x), FX_FX32_TO_F32(room->description->light_2_vec.y), FX_FX32_TO_F32(room->description->light_2_vec.z) };
+	float light_2_col[3] = { room->description->light_2_color.r / 255.0f, room->description->light_2_color.g / 255.0f, room->description->light_2_color.b / 255.0f };
 
 #if 0
 	glLightfv(GL_LIGHT0, GL_POSITION, light_1_vec);

--- a/src/vec.c
+++ b/src/vec.c
@@ -15,6 +15,19 @@ void VEC_CrossProduct(const VecFx32 *a, const VecFx32 *b, VecFx32 *axb)
 	axb->z = z;
 }
 
+void VEC_CrossProduct3(const Vec3 *a, const Vec3 *b, Vec3 *axb)
+{
+	float x, y, z;
+
+	x = a->y * b->z - a->z * b->y;
+	y = a->z * b->x - a->x * b->z;
+	z = a->x * b->y - a->y * b->x;
+
+	axb->x = x;
+	axb->y = y;
+	axb->z = z;
+}
+
 void VEC_Normalize(const VecFx32 *pSrc, VecFx32 *pDst)
 {
 	float x = FX_FX32_TO_F32(pSrc->x);
@@ -24,6 +37,17 @@ void VEC_Normalize(const VecFx32 *pSrc, VecFx32 *pDst)
 	pDst->x = FX_F32_TO_FX32(x / len);
 	pDst->y = FX_F32_TO_FX32(y / len);
 	pDst->z = FX_F32_TO_FX32(z / len);
+}
+
+void VEC_Normalize3(const Vec3 *pSrc, Vec3 *pDst)
+{
+	float x = pSrc->x;
+	float y = pSrc->y;
+	float z = pSrc->z;
+	float len = sqrt(x * x + y * y + z * z);
+	pDst->x = x / len;
+	pDst->y = y / len;
+	pDst->z = z / len;
 }
 
 void MTX_MultVec33(const VecFx32* vec, const MtxFx33* m, VecFx32* dst)


### PR DESCRIPTION
- Add float versions of a few vector/matrix helpers
- Define toon table and pass it as a uniform
  - Remove successive calls to `glUseProgram` so the toon table uniform only needs to be updated once
- Change lighting-related vectors from `Vec4` to `Vec3`
- Add decal and toon polygon mode calculations to shader
- Pass material alpha to shader separately from alpha_scale (model alpha)
- Enable light override calculation for Octoliths